### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "c"
+run = "make run"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Run on Repl.it](https://repl.it/badge/github/progsis-espol/progsis-c-plantilla)](https://repl.it/github/progsis-espol/progsis-c-plantilla)
 # Plantilla genérica repositorio C
 Plantilla genérica para repositorios de proyectos desarrollados en el lenguaje C usando GCC y Make en LINUX.
 


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).